### PR TITLE
minecraft: fix rotation over z axis

### DIFF
--- a/src/minecraft/model.rs
+++ b/src/minecraft/model.rs
@@ -252,7 +252,7 @@ impl PartialModel {
                         match r.find_with(|k| "axis".cmp(&k.as_slice())).unwrap().as_string().unwrap() {
                             "x" => rot(2, 1),
                             "y" => rot(0, 2),
-                            "z" => rot(0, 1),
+                            "z" => rot(1, 0),
                             axis => fail!("invalid rotation axis {}", axis)
                         }
                     }


### PR DESCRIPTION
When a model (e.g. a torch on a wall) has a rotation over the z axis, we
were rotating the model the wrong way around.

---

I noticed this while using this on my usual world. All the torches on the wall were going _into_ the wall instead of away from it.

I think this is the right place to fix it, since AFAICT this is where we transform minecraft axes into the model which hematite uses, but I was never that good at geometry.
