### PR TITLE
Fix error introduced by latest rust: plugin syntax

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@
 
 #[macro_use]
 extern crate gfx_macros;
-
 extern crate cam;
 extern crate current;
 extern crate event;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 
 #![feature(collections, core, io, os, path, rustc_private, std_misc)]
 
-#[plugin]
+#![plugin(gfx_macros)]
 #[no_link]
 
 #[macro_use]

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -1,7 +1,7 @@
 use device;
 use device::draw::CommandBuffer;
 use gfx;
-use gfx::{ Device, DeviceHelper, ToSlice };
+use gfx::{ Device, DeviceExt, ToSlice };
 use vecmath::Matrix4;
 
 static VERTEX: gfx::ShaderSource<'static> = shaders! {


### PR DESCRIPTION
Build will fail until https://github.com/bjz/gl-rs/pull/305 get's merged.