### PR TITLE
Rename DeviceHelper to DeviceExt in gfx usage.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,11 @@
 
 #![feature(collections, core, io, os, path, rustc_private, std_misc)]
 
-#[plugin]
+#![plugin(gfx_macros)]
 #[no_link]
 
 #[macro_use]
 extern crate gfx_macros;
-
 extern crate cam;
 extern crate current;
 extern crate event;

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -1,7 +1,7 @@
 use device;
 use device::draw::CommandBuffer;
 use gfx;
-use gfx::{ Device, DeviceHelper, ToSlice };
+use gfx::{ Device, DeviceExt, ToSlice };
 use vecmath::Matrix4;
 
 static VERTEX: gfx::ShaderSource<'static> = shaders! {


### PR DESCRIPTION
Build was failing due to an update in gfx-rs. DeviceHelper has been renamed DeviceExt.