### PR TITLE
Switched dependency from 'cam' to 'camera_controllers'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,13 +2,13 @@
 name = "hematite"
 version = "0.0.0"
 dependencies = [
+ "camera_controllers 0.0.1 (git+https://github.com/PistonDevelopers/camera_controllers)",
  "fps_counter 0.0.1 (git+https://github.com/PistonDevelopers/fps_counter)",
  "gfx 0.2.0 (git+https://github.com/gfx-rs/gfx-rs)",
  "gfx_device_gl 0.2.0 (git+https://github.com/gfx-rs/gfx_device_gl)",
  "gfx_macros 0.1.6 (git+https://github.com/gfx-rs/gfx-rs)",
  "image 0.2.0-alpha.10 (git+https://github.com/PistonDevelopers/image)",
  "piston-texture 0.0.1 (git+https://github.com/PistonDevelopers/texture)",
- "piston3d-cam 0.0.4 (git+https://github.com/PistonDevelopers/cam)",
  "piston3d-gfx_voxel 0.0.3 (git+https://github.com/PistonDevelopers/gfx_voxel)",
  "pistoncore-event 0.0.10 (git+https://github.com/PistonDevelopers/event)",
  "pistoncore-input 0.0.5 (git+https://github.com/PistonDevelopers/input)",
@@ -31,6 +31,19 @@ source = "git+https://github.com/PistonDevelopers/array#60236e30680cceef98a91816
 name = "bitflags"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "camera_controllers"
+version = "0.0.1"
+source = "git+https://github.com/PistonDevelopers/camera_controllers#6d3660bb55f1ea2588ce52bb81366e974f6b0081"
+dependencies = [
+ "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston3d-cam 0.0.4 (git+https://github.com/PistonDevelopers/cam)",
+ "pistoncore-event 0.0.10 (git+https://github.com/PistonDevelopers/event)",
+ "pistoncore-input 0.0.5 (git+https://github.com/PistonDevelopers/input)",
+ "quaternion 0.0.4 (git+https://github.com/PistonDevelopers/quaternion.git)",
+ "vecmath 0.0.5 (git+https://github.com/PistonDevelopers/vecmath)",
+]
 
 [[package]]
 name = "clock_ticks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ git = "https://github.com/PistonDevelopers/sdl2_window"
 [dependencies.piston3d-gfx_voxel]
 git = "https://github.com/PistonDevelopers/gfx_voxel"
 
-[dependencies.piston3d-cam]
-git = "https://github.com/PistonDevelopers/cam"
+[dependencies.camera_controllers]
+git = "https://github.com/PistonDevelopers/camera_controllers"
 
 [dependencies.fps_counter]
 git = "https://github.com/PistonDevelopers/fps_counter"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
     old_path, os, plugin, rustc_private, std_misc)]
 #![plugin(gfx_macros)]
 
-extern crate cam;
+extern crate camera_controllers;
 extern crate event;
 extern crate flate;
 extern crate fps_counter;
@@ -135,7 +135,7 @@ fn main() {
     }
     println!("Finished loading chunks.");
 
-    let projection_mat = cam::CameraPerspective {
+    let projection_mat = camera_controllers::CameraPerspective {
         fov: 70.0,
         near_clip: 0.1,
         far_clip: 1000.0,
@@ -146,10 +146,10 @@ fn main() {
     }.projection();
     renderer.set_projection(projection_mat);
 
-    let mut first_person_settings = cam::FirstPersonSettings::keyboard_wasd();
+    let mut first_person_settings = camera_controllers::FirstPersonSettings::keyboard_wasd();
     first_person_settings.speed_horizontal = 8.0;
     first_person_settings.speed_vertical = 4.0;
-    let mut first_person = cam::FirstPerson::new(
+    let mut first_person = camera_controllers::FirstPerson::new(
         player_pos,
         first_person_settings
     );


### PR DESCRIPTION
`FirstPerson` is going to be removed in https://github.com/PistonDevelopers/cam/pull/50