### PR TITLE
Use WrappingOps for explicit integer overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,6 @@ version = "0.0.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 tags = []
 
-[profile.dev]
-opt-level = 2
-debug = false
-
 [profile.release]
 opt-level = 2
 debug = false


### PR DESCRIPTION
Prevents the game from panicking when compiled with overflow checks enabled. Also includes a change to Cargo.toml to re-enable debug building - they're split up in case that was intended for some other reason.