### PR TITLE
[WIP] Fix #215 - Remove quack library usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,8 @@ dependencies = [
  "gfx_device_gl 0.2.5 (git+https://github.com/gfx-rs/gfx_device_gl)",
  "gfx_macros 0.1.11 (git+https://github.com/gfx-rs/gfx_macros)",
  "image 0.3.9 (git+https://github.com/PistonDevelopers/image)",
- "mmap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mmap 0.1.1 (git+https://github.com/retep998/rust-mmap)",
  "piston3d-gfx_voxel 0.0.5 (git+https://github.com/PistonDevelopers/gfx_voxel)",
  "pistoncore-event 0.1.3 (git+https://github.com/PistonDevelopers/event)",
  "pistoncore-input 0.0.9 (git+https://github.com/PistonDevelopers/input)",
@@ -226,10 +227,9 @@ dependencies = [
 [[package]]
 name = "mmap"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/retep998/rust-mmap#4617dd0901d6899faebfbc427714b89fcb889880"
 dependencies = [
  "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -396,14 +396,6 @@ dependencies = [
 name = "shader_version"
 version = "0.0.6"
 source = "git+https://github.com/PistonDevelopers/shader_version#14aa73be33b6d23d6b3cb27f94426545372df287"
-
-[[package]]
-name = "tempdir"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "time"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,29 +2,31 @@
 name = "hematite"
 version = "0.0.0"
 dependencies = [
- "camera_controllers 0.0.1 (git+https://github.com/PistonDevelopers/camera_controllers)",
- "fps_counter 0.0.1 (git+https://github.com/PistonDevelopers/fps_counter)",
- "gfx 0.2.2 (git+https://github.com/gfx-rs/gfx-rs)",
- "gfx_device_gl 0.2.1 (git+https://github.com/gfx-rs/gfx_device_gl)",
- "gfx_macros 0.1.8 (git+https://github.com/gfx-rs/gfx_macros)",
- "image 0.2.0 (git+https://github.com/PistonDevelopers/image)",
- "piston3d-gfx_voxel 0.0.4 (git+https://github.com/PistonDevelopers/gfx_voxel)",
- "pistoncore-event 0.0.10 (git+https://github.com/PistonDevelopers/event)",
- "pistoncore-input 0.0.5 (git+https://github.com/PistonDevelopers/input)",
- "pistoncore-sdl2_window 0.0.5 (git+https://github.com/PistonDevelopers/sdl2_window)",
- "pistoncore-window 0.0.13 (git+https://github.com/PistonDevelopers/window)",
- "quack 0.0.13 (git+https://github.com/PistonDevelopers/quack)",
- "rustc-serialize 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "sdl2 0.0.28 (git+https://github.com/AngryLawyer/rust-sdl2)",
- "shader_version 0.0.2 (git+https://github.com/PistonDevelopers/shader_version)",
- "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "vecmath 0.0.5 (git+https://github.com/PistonDevelopers/vecmath)",
+ "byteorder 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "camera_controllers 0.0.3 (git+https://github.com/PistonDevelopers/camera_controllers)",
+ "flate2 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fps_counter 0.0.2 (git+https://github.com/PistonDevelopers/fps_counter)",
+ "gfx 0.4.0 (git+https://github.com/gfx-rs/gfx-rs)",
+ "gfx_device_gl 0.2.5 (git+https://github.com/gfx-rs/gfx_device_gl)",
+ "gfx_macros 0.1.11 (git+https://github.com/gfx-rs/gfx_macros)",
+ "image 0.3.9 (git+https://github.com/PistonDevelopers/image)",
+ "mmap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston3d-gfx_voxel 0.0.5 (git+https://github.com/PistonDevelopers/gfx_voxel)",
+ "pistoncore-event 0.1.3 (git+https://github.com/PistonDevelopers/event)",
+ "pistoncore-input 0.0.9 (git+https://github.com/PistonDevelopers/input)",
+ "pistoncore-sdl2_window 0.0.13 (git+https://github.com/PistonDevelopers/sdl2_window)",
+ "pistoncore-window 0.1.2 (git+https://github.com/PistonDevelopers/window)",
+ "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sdl2 0.2.3 (git+https://github.com/AngryLawyer/rust-sdl2)",
+ "shader_version 0.0.6 (git+https://github.com/PistonDevelopers/shader_version)",
+ "time 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vecmath 0.0.22 (git+https://github.com/PistonDevelopers/vecmath)",
 ]
 
 [[package]]
 name = "array"
-version = "0.0.0"
-source = "git+https://github.com/PistonDevelopers/array#60236e30680cceef98a91816c5f91270eb5625fe"
+version = "0.0.1"
+source = "git+https://github.com/PistonDevelopers/array#23a1b8a732ca8b40c3cbb04e1f70cd386b97699b"
 
 [[package]]
 name = "bitflags"
@@ -32,98 +34,123 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "byteorder"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "camera_controllers"
-version = "0.0.1"
-source = "git+https://github.com/PistonDevelopers/camera_controllers#6d3660bb55f1ea2588ce52bb81366e974f6b0081"
+version = "0.0.3"
+source = "git+https://github.com/PistonDevelopers/camera_controllers#aca14013af3dff1ad556ac79553092d96546092e"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "piston3d-cam 0.0.4 (git+https://github.com/PistonDevelopers/cam)",
- "pistoncore-event 0.0.10 (git+https://github.com/PistonDevelopers/event)",
- "pistoncore-input 0.0.5 (git+https://github.com/PistonDevelopers/input)",
- "quaternion 0.0.4 (git+https://github.com/PistonDevelopers/quaternion.git)",
- "vecmath 0.0.5 (git+https://github.com/PistonDevelopers/vecmath)",
+ "piston 0.1.1 (git+https://github.com/pistondevelopers/piston)",
+ "piston3d-cam 0.0.7 (git+https://github.com/PistonDevelopers/cam)",
+ "quaternion 0.0.6 (git+https://github.com/PistonDevelopers/quaternion.git)",
+ "vecmath 0.0.22 (git+https://github.com/PistonDevelopers/vecmath)",
 ]
 
 [[package]]
 name = "clock_ticks"
-version = "0.0.4"
-source = "git+https://github.com/tomaka/clock_ticks#6a3005279bedc406b13eea09ff92447f05ca0de6"
+version = "0.0.5"
+source = "git+https://github.com/tomaka/clock_ticks#462848731d99ed2f800e2e5a19e2d8ca3b11c90c"
+dependencies = [
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "draw_state"
-version = "0.0.1"
-source = "git+https://github.com/gfx-rs/draw_state#b92422e8671a25f8fe5c8216001b44f5ca849744"
+version = "0.0.7"
+source = "git+https://github.com/gfx-rs/draw_state#44a0aed11abccbf970fc7efbe84b6482f0548248"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "enum_primitive"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "flate2"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fps_counter"
-version = "0.0.1"
-source = "git+https://github.com/PistonDevelopers/fps_counter#ef5ba6867768d893c277d721278d2342b78b32a4"
+version = "0.0.2"
+source = "git+https://github.com/PistonDevelopers/fps_counter#69e2334a697249fa611669595589baedda2ff571"
 dependencies = [
- "time 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock_ticks 0.0.5 (git+https://github.com/tomaka/clock_ticks)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gfx"
-version = "0.2.2"
-source = "git+https://github.com/gfx-rs/gfx-rs#5cbf5071369a884445f148b326be1d9f19476a4c"
+version = "0.4.0"
+source = "git+https://github.com/gfx-rs/gfx-rs#6957ff88e1a52be56a8b161afbff81e592d24c3d"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "draw_state 0.0.1 (git+https://github.com/gfx-rs/draw_state)",
- "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "draw_state 0.0.7 (git+https://github.com/gfx-rs/draw_state)",
+ "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gfx_device_gl"
-version = "0.2.1"
-source = "git+https://github.com/gfx-rs/gfx_device_gl#8a85a4521d8e211f4667732d3d162da9cade7213"
+version = "0.2.5"
+source = "git+https://github.com/gfx-rs/gfx_device_gl#9cc4e61afa1b322780c45d85f96163fc8df1c8f0"
 dependencies = [
- "gfx 0.2.2 (git+https://github.com/gfx-rs/gfx-rs)",
- "gfx_gl 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx 0.4.0 (git+https://github.com/gfx-rs/gfx-rs)",
+ "gfx_gl 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gfx_gl"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gl_common 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_generator 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gfx_macros"
-version = "0.1.8"
-source = "git+https://github.com/gfx-rs/gfx_macros#a50f67440f9e8212fa82442937d28d7738d58fbc"
+version = "0.1.11"
+source = "git+https://github.com/gfx-rs/gfx_macros#6e44e10a94a52065baa47c88d678a41a67622326"
 
 [[package]]
 name = "gl"
-version = "0.0.9"
-source = "git+https://github.com/bjz/gl-rs#645c9e75b4f603133d28ad0fb412535cdc3c67be"
+version = "0.0.12"
+source = "git+https://github.com/bjz/gl-rs#62b66a85e4c2c0d88fb916040bc462702c8e0346"
 dependencies = [
  "gl_common 0.0.4 (git+https://github.com/bjz/gl-rs)",
- "gl_generator 0.0.19 (git+https://github.com/bjz/gl-rs)",
+ "gl_generator 0.0.25 (git+https://github.com/bjz/gl-rs)",
  "khronos_api 0.0.5 (git+https://github.com/bjz/gl-rs)",
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gl_common"
 version = "0.0.4"
-source = "git+https://github.com/bjz/gl-rs#645c9e75b4f603133d28ad0fb412535cdc3c67be"
+source = "git+https://github.com/bjz/gl-rs#62b66a85e4c2c0d88fb916040bc462702c8e0346"
 dependencies = [
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -131,41 +158,43 @@ name = "gl_common"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gl_generator"
-version = "0.0.19"
-source = "git+https://github.com/bjz/gl-rs#645c9e75b4f603133d28ad0fb412535cdc3c67be"
+version = "0.0.25"
+source = "git+https://github.com/bjz/gl-rs#62b66a85e4c2c0d88fb916040bc462702c8e0346"
 dependencies = [
  "khronos_api 0.0.5 (git+https://github.com/bjz/gl-rs)",
- "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gl_generator"
-version = "0.0.19"
+version = "0.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "khronos_api 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "image"
-version = "0.2.0"
-source = "git+https://github.com/PistonDevelopers/image#92a5cec81b08bfd4e829bf0e2873575934d2ee3a"
+version = "0.3.9"
+source = "git+https://github.com/PistonDevelopers/image#04d84943a8cd5950707310e631f9e3b890dc84ed"
 dependencies = [
- "num 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enum_primitive 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "khronos_api"
 version = "0.0.5"
-source = "git+https://github.com/bjz/gl-rs#645c9e75b4f603133d28ad0fb412535cdc3c67be"
+source = "git+https://github.com/bjz/gl-rs#62b66a85e4c2c0d88fb916040bc462702c8e0346"
 
 [[package]]
 name = "khronos_api"
@@ -174,30 +203,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.2"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "num"
-version = "0.1.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "piston-gfx_texture"
-version = "0.0.4"
-source = "git+https://github.com/PistonDevelopers/gfx_texture#0953cf106e4c9cf61a2869d5f1fc9684ceb10731"
+name = "miniz-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gfx 0.2.2 (git+https://github.com/gfx-rs/gfx-rs)",
- "image 0.2.0 (git+https://github.com/PistonDevelopers/image)",
+ "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mmap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "piston"
+version = "0.1.1"
+source = "git+https://github.com/pistondevelopers/piston#e4b588cf22275acb230a4d6baace2567ea66391a"
+dependencies = [
+ "pistoncore-event 0.1.3 (git+https://github.com/PistonDevelopers/event)",
+ "pistoncore-input 0.0.9 (git+https://github.com/PistonDevelopers/input)",
+ "pistoncore-window 0.1.2 (git+https://github.com/PistonDevelopers/window)",
+]
+
+[[package]]
+name = "piston-float"
+version = "0.0.1"
+source = "git+https://github.com/pistondevelopers/float#2c73a3e34c384c79e95b35c069d5a69dda3a0cc4"
+
+[[package]]
+name = "piston-gfx_texture"
+version = "0.0.6"
+source = "git+https://github.com/PistonDevelopers/gfx_texture#dc28daf29058f2e2869b044f41e575c1423a3c04"
+dependencies = [
+ "gfx 0.4.0 (git+https://github.com/gfx-rs/gfx-rs)",
+ "image 0.3.9 (git+https://github.com/PistonDevelopers/image)",
  "piston-texture 0.0.1 (git+https://github.com/PistonDevelopers/texture)",
 ]
 
@@ -207,159 +272,159 @@ version = "0.0.1"
 source = "git+https://github.com/PistonDevelopers/texture#3cc4cddc3f8c51c36ea11dd2f63d70aa887f53fb"
 
 [[package]]
-name = "piston3d-cam"
-version = "0.0.4"
-source = "git+https://github.com/PistonDevelopers/cam#729d7d2c31307ea877b16e7dc678c5b7ad0fcbf1"
+name = "piston-viewport"
+version = "0.0.2"
+source = "git+https://github.com/pistondevelopers/viewport#3819edeb0982d2552669e03ad9c0317e75340510"
 dependencies = [
- "quaternion 0.0.4 (git+https://github.com/PistonDevelopers/quaternion.git)",
- "vecmath 0.0.5 (git+https://github.com/PistonDevelopers/vecmath)",
+ "piston-float 0.0.1 (git+https://github.com/pistondevelopers/float)",
+]
+
+[[package]]
+name = "piston3d-cam"
+version = "0.0.7"
+source = "git+https://github.com/PistonDevelopers/cam#1614566c3cc6f5e4f93279575d5e13af83cd131d"
+dependencies = [
+ "quaternion 0.0.6 (git+https://github.com/PistonDevelopers/quaternion.git)",
+ "vecmath 0.0.22 (git+https://github.com/PistonDevelopers/vecmath)",
 ]
 
 [[package]]
 name = "piston3d-gfx_voxel"
-version = "0.0.4"
-source = "git+https://github.com/PistonDevelopers/gfx_voxel#3a9a37cdb5b8089f4b0b60bb976d68838e0d3739"
+version = "0.0.5"
+source = "git+https://github.com/PistonDevelopers/gfx_voxel#153fb6a85f0b88360021ecd5b14c9359c2786b83"
 dependencies = [
- "array 0.0.0 (git+https://github.com/PistonDevelopers/array)",
- "gfx 0.2.2 (git+https://github.com/gfx-rs/gfx-rs)",
- "image 0.2.0 (git+https://github.com/PistonDevelopers/image)",
- "piston-gfx_texture 0.0.4 (git+https://github.com/PistonDevelopers/gfx_texture)",
- "vecmath 0.0.5 (git+https://github.com/PistonDevelopers/vecmath)",
+ "array 0.0.1 (git+https://github.com/PistonDevelopers/array)",
+ "gfx 0.4.0 (git+https://github.com/gfx-rs/gfx-rs)",
+ "image 0.3.9 (git+https://github.com/PistonDevelopers/image)",
+ "piston-gfx_texture 0.0.6 (git+https://github.com/PistonDevelopers/gfx_texture)",
 ]
 
 [[package]]
 name = "pistoncore-event"
-version = "0.0.10"
-source = "git+https://github.com/PistonDevelopers/event#4166dc0c4df895e72c1336e04635b9a48dd5291f"
+version = "0.1.3"
+source = "git+https://github.com/PistonDevelopers/event#c51e721f4b346fe7cc8a4c0e2658a70d257202ce"
 dependencies = [
- "pistoncore-event_loop 0.0.13 (git+https://github.com/PistonDevelopers/event_loop)",
- "pistoncore-input 0.0.5 (git+https://github.com/PistonDevelopers/input)",
- "pistoncore-window 0.0.13 (git+https://github.com/PistonDevelopers/window)",
+ "pistoncore-event_loop 0.1.5 (git+https://github.com/PistonDevelopers/event_loop)",
+ "pistoncore-input 0.0.9 (git+https://github.com/PistonDevelopers/input)",
+ "pistoncore-window 0.1.2 (git+https://github.com/PistonDevelopers/window)",
 ]
 
 [[package]]
 name = "pistoncore-event_loop"
-version = "0.0.13"
-source = "git+https://github.com/PistonDevelopers/event_loop#4d6193547f22064c7ea9ab5a2ff96fdbd2c847e3"
+version = "0.1.5"
+source = "git+https://github.com/PistonDevelopers/event_loop#d7541e44e33016b0584579e800879120cf982639"
 dependencies = [
- "clock_ticks 0.0.4 (git+https://github.com/tomaka/clock_ticks)",
- "pistoncore-window 0.0.13 (git+https://github.com/PistonDevelopers/window)",
- "quack 0.0.13 (git+https://github.com/PistonDevelopers/quack)",
+ "clock_ticks 0.0.5 (git+https://github.com/tomaka/clock_ticks)",
+ "piston-viewport 0.0.2 (git+https://github.com/pistondevelopers/viewport)",
+ "pistoncore-window 0.1.2 (git+https://github.com/PistonDevelopers/window)",
 ]
 
 [[package]]
 name = "pistoncore-input"
-version = "0.0.5"
-source = "git+https://github.com/PistonDevelopers/input#3e6d11cef33c1384915aa513fbb1481f1212eb6e"
+version = "0.0.9"
+source = "git+https://github.com/PistonDevelopers/input#cb0615041f0dd1e4cd1cfc6d4e0e4bae0a575a8e"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pistoncore-sdl2_window"
-version = "0.0.5"
-source = "git+https://github.com/PistonDevelopers/sdl2_window#6862eef60b272fa5112652bebf701332c65aff78"
+version = "0.0.13"
+source = "git+https://github.com/PistonDevelopers/sdl2_window#d9dd95cadd5c8de09ddb163812761738b999b3f4"
 dependencies = [
- "gl 0.0.9 (git+https://github.com/bjz/gl-rs)",
- "pistoncore-input 0.0.5 (git+https://github.com/PistonDevelopers/input)",
- "pistoncore-window 0.0.13 (git+https://github.com/PistonDevelopers/window)",
- "quack 0.0.13 (git+https://github.com/PistonDevelopers/quack)",
- "sdl2 0.0.28 (git+https://github.com/AngryLawyer/rust-sdl2)",
- "shader_version 0.0.2 (git+https://github.com/PistonDevelopers/shader_version)",
+ "gl 0.0.12 (git+https://github.com/bjz/gl-rs)",
+ "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston 0.1.1 (git+https://github.com/pistondevelopers/piston)",
+ "sdl2 0.2.3 (git+https://github.com/AngryLawyer/rust-sdl2)",
+ "shader_version 0.0.6 (git+https://github.com/PistonDevelopers/shader_version)",
 ]
 
 [[package]]
 name = "pistoncore-window"
-version = "0.0.13"
-source = "git+https://github.com/PistonDevelopers/window#711cb7a147eda15fa7e65ecc5484f471dc1b85fc"
+version = "0.1.2"
+source = "git+https://github.com/PistonDevelopers/window#73314c130ce0b8fc22e47fc636a4724b6e02a365"
 dependencies = [
- "pistoncore-input 0.0.5 (git+https://github.com/PistonDevelopers/input)",
- "quack 0.0.13 (git+https://github.com/PistonDevelopers/quack)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.0.9 (git+https://github.com/PistonDevelopers/input)",
 ]
-
-[[package]]
-name = "quack"
-version = "0.0.13"
-source = "git+https://github.com/PistonDevelopers/quack#6bcb6ac300267d0ea5f96d881a9649e41f12b7b2"
 
 [[package]]
 name = "quaternion"
-version = "0.0.4"
-source = "git+https://github.com/PistonDevelopers/quaternion.git#cad25d95b2fca98917fa40c04cbd95b63d29f20d"
+version = "0.0.6"
+source = "git+https://github.com/PistonDevelopers/quaternion.git#6dce2181e558779abd71a8293ac60d22ba504d80"
 dependencies = [
- "vecmath 0.0.5 (git+https://github.com/PistonDevelopers/vecmath)",
+ "vecmath 0.0.22 (git+https://github.com/PistonDevelopers/vecmath)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.1"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sdl2"
-version = "0.0.28"
-source = "git+https://github.com/AngryLawyer/rust-sdl2#f2e7c4fb354907bfa9476343ac34c6af58870681"
+version = "0.2.3"
+source = "git+https://github.com/AngryLawyer/rust-sdl2#f270e9879cd91324a3adc7c0367971e7cda27b9c"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sdl2-sys 0.0.27 (git+https://github.com/AngryLawyer/rust-sdl2)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sdl2-sys 0.2.2 (git+https://github.com/AngryLawyer/rust-sdl2)",
 ]
 
 [[package]]
 name = "sdl2-sys"
-version = "0.0.27"
-source = "git+https://github.com/AngryLawyer/rust-sdl2#f2e7c4fb354907bfa9476343ac34c6af58870681"
+version = "0.2.2"
+source = "git+https://github.com/AngryLawyer/rust-sdl2#f270e9879cd91324a3adc7c0367971e7cda27b9c"
 dependencies = [
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "shader_version"
-version = "0.0.2"
-source = "git+https://github.com/PistonDevelopers/shader_version#cd02a715d3148b6820e548ea79ffd76c663b9e1c"
+version = "0.0.6"
+source = "git+https://github.com/PistonDevelopers/shader_version#14aa73be33b6d23d6b3cb27f94426545372df287"
+
+[[package]]
+name = "tempdir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "time"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "vecmath"
-version = "0.0.5"
-source = "git+https://github.com/PistonDevelopers/vecmath#6284864573fe185f4d87aadfe38d0fc3b2edcd73"
+version = "0.0.22"
+source = "git+https://github.com/PistonDevelopers/vecmath#d6bb5cf609b51cae8f296945e179bd42a74c9a51"
+dependencies = [
+ "piston-float 0.0.1 (git+https://github.com/pistondevelopers/float)",
+]
 
 [[package]]
 name = "xml-rs"
-version = "0.1.20"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,11 @@ name = "hematite"
 path = "src/main.rs"
 
 [dependencies]
+byteorder = "0.3"
+flate2 = "0.2"
+mmap = "*"
+rustc-serialize = "0.3"
 time = "*"
-rustc-serialize = "0.2.8"
 
 [dependencies.sdl2]
 git = "https://github.com/AngryLawyer/rust-sdl2"
@@ -60,5 +63,3 @@ git = "https://github.com/gfx-rs/gfx_device_gl"
 [dependencies.shader_version]
 git = "https://github.com/PistonDevelopers/shader_version"
 
-[dependencies.quack]
-git = "https://github.com/PistonDevelopers/quack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,12 @@ path = "src/main.rs"
 [dependencies]
 byteorder = "0.3"
 flate2 = "0.2"
-mmap = "*"
+libc = "*"
 rustc-serialize = "0.3"
 time = "*"
+
+[dependencies.mmap]
+git = "https://github.com/retep998/rust-mmap"
 
 [dependencies.sdl2]
 git = "https://github.com/AngryLawyer/rust-sdl2"

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -5,19 +5,19 @@ use array::*;
 use shader::Buffer;
 use gfx;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct BlockState {
     pub value: u16
 }
 
 pub const EMPTY_BLOCK: BlockState = BlockState { value: 0 };
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct BiomeId {
     pub value: u8
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct LightLevel {
     pub value: u8
 }
@@ -87,7 +87,7 @@ impl<R: gfx::Resources> ChunkManager<R> {
                     )
                 );
             let central = columns[1][1].unwrap();
-            for y in range(0, central.chunks.len()) {
+            for y in 0..central.chunks.len() {
                 let chunks = [-1, 0, 1].map(|dy| {
                     let y = y as i32 + dy;
                     columns.map(

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,6 @@ use std::path::Path;
 
 use array::*;
 use event::{ Event, Events };
-use event::render::RenderEvent;
 use sdl2_window::Sdl2Window;
 use shader::Renderer;
 use vecmath::{ vec3_add, vec3_scale, vec3_normalized };
@@ -94,14 +93,13 @@ fn main() {
         );
     let window = Sdl2Window::new(
         shader_version::OpenGL::_3_3,
-        WindowSettings {
-            title: loading_title,
-            size: Size { width: 854, height: 480 },
-            fullscreen: false,
-            exit_on_esc: true,
-            samples: 0,
-            vsync: false,
-        }
+        WindowSettings::new(
+            loading_title,
+            Size { width: 854, height: 480 })
+            .fullscreen(false)
+            .exit_on_esc(true)
+            .samples(0)
+            .vsync(false)
     );
 
     let (mut device, mut factory) = gfx_device_gl::create(|s| unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
     });
 
     let Size { width: w, height: h } = window.size();
-    let frame = gfx::Frame::<gfx_device_gl::Resources>::empty(w as u16, h as u16);
+    let frame = factory.make_fake_output(w as u16, h as u16);
 
     let assets = Path::new("./assets");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
     let world = Path::new(&world);
 
     let level_gzip = Vec::<u8>::new();
-    let _ = File::open(&world.join("level.dat")).unwrap()
+    let _ = File::open(world.join("level.dat")).unwrap()
         .read_to_end(&mut level_gzip).unwrap();
     let level = minecraft::nbt::Nbt::from_gzip(level_gzip.as_slice())
         .unwrap();
@@ -125,8 +125,8 @@ fn main() {
 
     println!("Started loading chunks...");
     let [cx_base, cz_base] = player_chunk.map(|x| max(0, (x & 0x1f) - 8) as u8);
-    for cz in (cz_base..cz_base + 16) {
-        for cx in (cx_base..cx_base + 16) {
+    for cz in cz_base..cz_base + 16 {
+        for cx in cx_base..cx_base + 16 {
             match region.get_chunk_column(cx, cz) {
                 Some(column) => {
                     let [cx, cz] = [
@@ -179,7 +179,7 @@ fn main() {
 
     let mut staging_buffer = vec![];
     let ref window = RefCell::new(window);
-    for e in Events::new(window)
+    for e in window.borrow_mut().events()
         .ups(120)
         .max_fps(10_000) {
         use input::Button::Keyboard;
@@ -264,7 +264,7 @@ fn main() {
                         (frame_end_time - end_time) as f64 / 1e6,
                         fps, world.display()
                     );
-                window.borrow_mut().window.set_title(title);
+                window.borrow_mut().set_title(title);
             }
             Event::Update(_) => {
                 // HACK(eddyb) find the closest chunk to the player.

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
     let world = Path::new(&world);
 
     let level_gzip = Vec::<u8>::new();
-    let len = File::open(&world.join("level.dat")).unwrap()
+    let _ = File::open(&world.join("level.dat")).unwrap()
         .read_to_end(&mut level_gzip).unwrap();
     let level = minecraft::nbt::Nbt::from_gzip(level_gzip.as_slice())
         .unwrap();
@@ -109,7 +109,7 @@ fn main() {
     });
 
     let Size { width: w, height: h } = window.size();
-    let frame = gfx::Frame::new(w as u16, h as u16);
+    let frame = gfx::Frame::<gfx_device_gl::Resources>::empty(w as u16, h as u16);
 
     let assets = Path::new("./assets");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ extern crate gfx_device_gl;
 extern crate gfx_voxel;
 extern crate image;
 extern crate input;
+extern crate libc;
 extern crate mmap;
 extern crate sdl2;
 extern crate sdl2_window;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,18 @@
-#![feature(box_syntax, collections, core, custom_attribute, old_io,
-    old_path, os, plugin, rustc_private, std_misc)]
+#![feature(box_syntax, collections, core, custom_attribute,
+    os, plugin, rustc_private, std_misc, slice_patterns)]
 #![plugin(gfx_macros)]
 
+extern crate byteorder;
 extern crate camera_controllers;
 extern crate event;
-extern crate flate;
+extern crate flate2;
 extern crate fps_counter;
 extern crate gfx;
 extern crate gfx_device_gl;
 extern crate gfx_voxel;
 extern crate image;
 extern crate input;
-extern crate quack;
+extern crate mmap;
 extern crate sdl2;
 extern crate sdl2_window;
 extern crate shader_version;
@@ -19,26 +20,28 @@ extern crate time;
 extern crate vecmath;
 extern crate window;
 
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 
 // Reexport modules from gfx_voxel while stuff is moving
 // from Hematite to the library.
 pub use gfx_voxel::{ array, cube };
 
+use std::io::prelude::*;
 use std::cell::RefCell;
 use std::cmp::max;
 use std::f32::consts::PI;
 use std::f32::INFINITY;
-use std::old_io::fs::File;
-use std::num::Float;
+use std::fs::File;
+use std::io::Result;
+use std::path::Path;
 
 use array::*;
-use event::{ Event, Events, MaxFps, Ups };
-use quack::{Get, Set};
+use event::{ Event, Events };
+use event::render::RenderEvent;
 use sdl2_window::Sdl2Window;
 use shader::Renderer;
 use vecmath::{ vec3_add, vec3_scale, vec3_normalized };
-use window::{ CaptureCursor, Size, WindowSettings };
+use window::{ Size, Window, AdvancedWindow, WindowSettings };
 
 use minecraft::biome::Biomes;
 use minecraft::block_state::BlockStates;
@@ -49,7 +52,7 @@ pub mod shader;
 pub mod minecraft {
     pub use self::data_1_8_pre2 as data;
 
-    mod data_1_8_pre2;
+    pub mod data_1_8_pre2;
     pub mod biome;
     pub mod block_state;
     pub mod model;
@@ -62,8 +65,9 @@ fn main() {
     let world = args.nth(1).expect("Usage: ./hematite <path/to/world>");
     let world = Path::new(&world);
 
-    let level_gzip = File::open(&world.join("level.dat"))
-        .read_to_end().unwrap();
+    let level_gzip = Vec::<u8>::new();
+    let len = File::open(&world.join("level.dat")).unwrap()
+        .read_to_end(&mut level_gzip).unwrap();
     let level = minecraft::nbt::Nbt::from_gzip(level_gzip.as_slice())
         .unwrap();
     println!("{:?}", level);
@@ -86,22 +90,25 @@ fn main() {
 
     let loading_title = format!(
             "Hematite loading... - {}",
-            world.filename_display()
+            world.display()
         );
     let window = Sdl2Window::new(
         shader_version::OpenGL::_3_3,
         WindowSettings {
             title: loading_title,
-            size: [854, 480],
+            size: Size { width: 854, height: 480 },
             fullscreen: false,
             exit_on_esc: true,
             samples: 0,
+            vsync: false,
         }
     );
-    let mut device = gfx_device_gl::GlDevice::new(|s| unsafe {
+
+    let (mut device, mut factory) = gfx_device_gl::create(|s| unsafe {
         std::mem::transmute(sdl2::video::gl_get_proc_address(s))
     });
-    let Size([w, h]) = window.get();
+
+    let Size { width: w, height: h } = window.size();
     let frame = gfx::Frame::new(w as u16, h as u16);
 
     let assets = Path::new("./assets");
@@ -110,16 +117,16 @@ fn main() {
     let biomes = Biomes::load(&assets);
 
     // Load block state definitions and models.
-    let block_states = BlockStates::load(&assets, &mut device);
+    let block_states = BlockStates::load(&assets, &mut device, &mut factory);
 
-    let mut renderer = Renderer::new(device, frame, block_states.texture().handle.clone());
+    let mut renderer = Renderer::new(device, factory, frame, block_states.texture.handle.clone());
 
     let mut chunk_manager = chunk::ChunkManager::new();
 
     println!("Started loading chunks...");
     let [cx_base, cz_base] = player_chunk.map(|x| max(0, (x & 0x1f) - 8) as u8);
-    for cz in range(cz_base, cz_base + 16) {
-        for cx in range(cx_base, cx_base + 16) {
+    for cz in (cz_base..cz_base + 16) {
+        for cx in (cx_base..cx_base + 16) {
             match region.get_chunk_column(cx, cz) {
                 Some(column) => {
                     let [cx, cz] = [
@@ -139,7 +146,7 @@ fn main() {
         near_clip: 0.1,
         far_clip: 1000.0,
         aspect_ratio: {
-            let Size([w, h]) = window.get();
+            let Size { width: w, height: h } = window.size();
             (w as f32) / (h as f32)
         }
     }.projection();
@@ -173,8 +180,8 @@ fn main() {
     let mut staging_buffer = vec![];
     let ref window = RefCell::new(window);
     for e in Events::new(window)
-        .set(Ups(120))
-        .set(MaxFps(10_000)) {
+        .ups(120)
+        .max_fps(10_000) {
         use input::Button::Keyboard;
         use input::Input::{ Move, Press };
         use input::keyboard::Key;
@@ -255,9 +262,9 @@ fn main() {
                         num_total_chunks,
                         (end_time - start_time) as f64 / 1e6,
                         (frame_end_time - end_time) as f64 / 1e6,
-                        fps, world.filename_display()
+                        fps, world.display()
                     );
-                window.borrow_mut().window.set_title(title.as_slice()).unwrap();
+                window.borrow_mut().window.set_title(title);
             }
             Event::Update(_) => {
                 // HACK(eddyb) find the closest chunk to the player.
@@ -302,7 +309,7 @@ fn main() {
                     if capture_cursor { "off" } else { "on" });
                 capture_cursor = !capture_cursor;
 
-                window.set(CaptureCursor(capture_cursor));
+                window.borrow_mut().capture_cursor(capture_cursor);
             }
             Event::Input(Move(MouseRelative(_, _))) => {
                 if !capture_cursor {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-#![feature(box_syntax, collections, core, custom_attribute,
-    os, plugin, rustc_private, std_misc, slice_patterns)]
+#![feature(box_syntax, collections, convert, core,
+    custom_attribute, plugin, slice_patterns)]
 #![plugin(gfx_macros)]
 
 extern crate byteorder;
@@ -32,7 +32,6 @@ use std::cmp::max;
 use std::f32::consts::PI;
 use std::f32::INFINITY;
 use std::fs::File;
-use std::io::Result;
 use std::path::Path;
 use std::rc::Rc;
 

--- a/src/minecraft/biome.rs
+++ b/src/minecraft/biome.rs
@@ -1,10 +1,11 @@
 use std::ops::Index;
+use std::path::Path;
 
 use chunk::BiomeId;
 use minecraft::data;
 use gfx_voxel::texture::ColorMap;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Biome {
     pub name: &'static str,
     pub temperature: f32,
@@ -43,7 +44,7 @@ impl Biomes {
 impl Index<BiomeId> for Biomes {
     type Output = Biome;
 
-    fn index<'a>(&'a self, id: &BiomeId) -> &'a Biome {
+    fn index<'a>(&'a self, id: BiomeId) -> &'a Biome {
         self.biomes[id.value as usize].as_ref().unwrap()
     }
 }

--- a/src/minecraft/block_state.rs
+++ b/src/minecraft/block_state.rs
@@ -542,7 +542,6 @@ pub fn fill_buffer<R: gfx::Resources>(block_states: &BlockStates<R>,
                                     model::Tint::None | model::Tint::Redstone => continue,
                                     model::Tint::Grass | model::Tint::Foliage => {}
                                 }
-                                let [x, z] = [x, z].map(|x| x as usize);
                                 let [x, z] = [x.wrapping_add(dx as usize), z.wrapping_add(dz as usize)].map(|x| x.wrapping_add(16));
                                 let biome = match column_biomes[z / 16][x / 16] {
                                     Some(biome) => biomes[biome[z % 16][x % 16]],

--- a/src/minecraft/block_state.rs
+++ b/src/minecraft/block_state.rs
@@ -139,7 +139,7 @@ impl<R: gfx::Resources> BlockStates<R> {
                 // Note: excluding paeonia itself, which works as-is.
                 let num_plants = lower.count();
 
-                for j in (i - 1 - num_plants..i - 1) {
+                for j in i - 1 - num_plants..i - 1 {
                     last_id += 1;
                     let (_, lower_name, _) = BLOCK_STATES[j];
                     extras.push(Description {
@@ -400,12 +400,11 @@ pub fn fill_buffer<R: gfx::Resources>(block_states: &BlockStates<R>,
                    coords: [i32; 3], chunks: [[[&Chunk; 3]; 3]; 3],
                    column_biomes: [[Option<&[[BiomeId; 16]; 16]>; 3]; 3]) {
     let chunk_xyz = coords.map(|x| x as f32 * 16.0);
-    for y in 0..16 {
-        for z in 0..16 {
-            for x in 0..16 {
+    for y in 0..16_usize {
+        for z in 0..16_usize {
+            for x in 0..16_usize {
                 let at = |dir: [i32; 3]| {
                     let [dx, dy, dz] = dir.map(|x| x as usize);
-                    let [x, y, z] = [x, y, z].map(|x| x as usize);
                     let [x, y, z] = [x.wrapping_add(dx), y.wrapping_add(dy), z.wrapping_add(dz)].map(|x| x.wrapping_add(16));
                     let chunk = chunks[y / 16][z / 16][x / 16];
                     let [x, y, z] = [x, y, z].map(|x| x % 16);

--- a/src/minecraft/block_state.rs
+++ b/src/minecraft/block_state.rs
@@ -353,7 +353,7 @@ impl<R: gfx::Resources> BlockStates<R> {
         drop(partial_model_cache);
         drop(block_state_cache);
 
-        let texture = atlas.complete(&mut f);
+        let texture = atlas.complete(f);
         let (width, height) = texture.get_size();
         let u_unit = 1.0 / (width as f32);
         let v_unit = 1.0 / (height as f32);

--- a/src/minecraft/block_state.rs
+++ b/src/minecraft/block_state.rs
@@ -11,7 +11,6 @@ use chunk::{BiomeId, BlockState, Chunk};
 use cube;
 use gfx;
 use gfx_voxel::texture::{AtlasBuilder, ImageSize, Texture};
-use gfx_device_gl;
 use minecraft::biome::Biomes;
 use minecraft::data::BLOCK_STATES;
 use minecraft::model::OrthoRotation::*;
@@ -114,8 +113,8 @@ impl ModelAndBehavior {
 
 impl<R: gfx::Resources> BlockStates<R> {
 
-    pub fn load<D: gfx::Device, F: gfx::Factory<R>>(
-        assets: &Path, d: &mut D, f: &mut F
+    pub fn load<F: gfx::Factory<R>>(
+        assets: &Path, f: &mut F
     ) -> BlockStates<R> {
         let mut last_id = BLOCK_STATES.last().map_or(0, |state| state.0);
         let mut states = Vec::<Description>::with_capacity(BLOCK_STATES.len().next_power_of_two());
@@ -190,11 +189,11 @@ impl<R: gfx::Resources> BlockStates<R> {
         }
         states.extend(extras.into_iter());
 
-        BlockStates::load_with_states(assets, d, f, states)
+        BlockStates::load_with_states(assets, f, states)
     }
 
-    fn load_with_states<D: gfx::Device, F: gfx::Factory<R>>(
-        assets: &Path, d: &mut D, f: &mut F,
+    fn load_with_states<F: gfx::Factory<R>>(
+        assets: &Path, f: &mut F,
         states: Vec<Description>
     ) -> BlockStates<R> {
         struct Variant {

--- a/src/minecraft/block_state.rs
+++ b/src/minecraft/block_state.rs
@@ -23,8 +23,8 @@ use vecmath::vec3_add;
 use self::PolymorphDecision::*;
 
 pub struct BlockStates<R: gfx::Resources> {
-    models: Vec<ModelAndBehavior>,
-    texture: Texture<R>,
+    pub models: Vec<ModelAndBehavior>,
+    pub texture: Texture<R>,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy)]

--- a/src/minecraft/block_state.rs
+++ b/src/minecraft/block_state.rs
@@ -270,7 +270,7 @@ impl<R: gfx::Resources> BlockStates<R> {
                 Cow::Owned(ref variant) => variants.get(variant),
                 Cow::Borrowed(variant) => variants.get(variant)
             }.unwrap();
-            let mut model = Model::load(variant.model.as_str(), assets,
+            let mut model = Model::load(&variant.model, assets,
                                         &mut atlas, &mut partial_model_cache);
 
             let rotate_faces = |m: &mut Model, ix: usize, iy: usize, rot_mat: [i32; 4]| {

--- a/src/minecraft/model.rs
+++ b/src/minecraft/model.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{ Occupied, Vacant };
-use std::f32::consts::{PI, SQRT2};
+use std::f32::consts::{PI, SQRT_2};
 use std::f32::INFINITY;
-use std::old_io::fs::File;
-use std::num::Float;
+use std::fs::File;
+use std::path::Path;
 use std::str::FromStr;
 
 use self::OrthoRotation::*;
@@ -13,7 +13,7 @@ use cube;
 use serialize::json;
 use gfx_voxel::texture::AtlasBuilder;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Vertex {
     pub xyz: [f32; 3],
     pub uv: [f32; 2]
@@ -27,7 +27,7 @@ pub enum Tint {
     Redstone
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum OrthoRotation {
     Rotate0,
     Rotate90,
@@ -116,7 +116,7 @@ impl PartialModel {
             Some(model) => return f(model, atlas),
             None => {}
         }
-        let path = assets.join(Path::new(format!("minecraft/models/{}.json", name).as_slice()));
+        let path = assets.join(Path::new(format!("minecraft/models/{}.json", name).as_str()));
         let obj = json::Json::from_reader(&mut File::open(&path).unwrap()).unwrap();
 
         let mut model = match obj.find("parent").and_then(|x| x.as_string()) {
@@ -160,7 +160,7 @@ impl PartialModel {
                 let element_start = model.faces.len();
 
                 for (k, v) in element.find("faces").unwrap().as_object().unwrap().iter() {
-                    let face: cube::Face = FromStr::from_str(k.as_slice()).unwrap();
+                    let face: cube::Face = FromStr::from_str(k.as_str()).unwrap();
                     let [u0, v0, u1, v1] = match v.find("uv") {
                         Some(uv) => {
                             Array::from_iter(uv.as_array().unwrap().iter().map(|x| x.as_f64().unwrap() as f32))
@@ -252,8 +252,8 @@ impl PartialModel {
 
                                 if rescale {
                                     for v in face.vertices.iter_mut() {
-                                        v.xyz[ix] *= SQRT2;
-                                        v.xyz[iy] *= SQRT2;
+                                        v.xyz[ix] *= SQRT_2;
+                                        v.xyz[iy] *= SQRT_2;
                                     }
                                 }
 
@@ -286,7 +286,7 @@ impl PartialModel {
 impl Model {
     pub fn load(name: &str, assets: &Path, atlas: &mut AtlasBuilder,
                 cache: &mut HashMap<String, PartialModel>) -> Model {
-        PartialModel::load(format!("block/{}", name).as_slice(), assets, atlas, cache, |partial, atlas| {
+        PartialModel::load(format!("block/{}", name).as_str(), assets, atlas, cache, |partial, atlas| {
             let mut faces: Vec<Face> = partial.faces.iter().map(|&(mut face, ref tex)| {
                 fn texture_coords(textures: &HashMap<String, PartialTexture>,
                                   tex: &String) -> Option<(f32, f32)> {

--- a/src/minecraft/model.rs
+++ b/src/minecraft/model.rs
@@ -160,7 +160,7 @@ impl PartialModel {
                 let element_start = model.faces.len();
 
                 for (k, v) in element.find("faces").unwrap().as_object().unwrap().iter() {
-                    let face: cube::Face = FromStr::from_str(k.as_str()).unwrap();
+                    let face: cube::Face = k.parse().unwrap();
                     let [u0, v0, u1, v1] = match v.find("uv") {
                         Some(uv) => {
                             Array::from_iter(uv.as_array().unwrap().iter().map(|x| x.as_f64().unwrap() as f32))
@@ -286,7 +286,7 @@ impl PartialModel {
 impl Model {
     pub fn load(name: &str, assets: &Path, atlas: &mut AtlasBuilder,
                 cache: &mut HashMap<String, PartialModel>) -> Model {
-        PartialModel::load(format!("block/{}", name).as_str(), assets, atlas, cache, |partial, atlas| {
+        PartialModel::load(&format!("block/{}", name), assets, atlas, cache, |partial, atlas| {
             let mut faces: Vec<Face> = partial.faces.iter().map(|&(mut face, ref tex)| {
                 fn texture_coords(textures: &HashMap<String, PartialTexture>,
                                   tex: &String) -> Option<(f32, f32)> {

--- a/src/minecraft/nbt.rs
+++ b/src/minecraft/nbt.rs
@@ -94,13 +94,13 @@ impl Nbt {
 
     pub fn from_gzip(data: &[u8]) -> io::Result<Nbt> {
         assert_eq!(&data[..4], &[0x1fu8, 0x8b, 0x08, 0x00]);
-        let data = GzDecoder::new(&data[10..]).ok().expect("inflate failed");
-        Nbt::from_reader(&mut BufReader::new(data))
+        let reader = GzDecoder::new(&data[10..]).unwrap();
+        Nbt::from_reader(&mut reader)
     }
 
     pub fn from_zlib(data: &[u8]) -> io::Result<Nbt> {
-        let data = ZlibDecoder::new(data);
-        Nbt::from_reader(&mut BufReader::new(data))
+        let reader = ZlibDecoder::new(data);
+        Nbt::from_reader(&mut reader)
     }
 
     pub fn as_byte(&self) -> Option<i8> {
@@ -156,8 +156,8 @@ const TAG_LIST: i8 = 9;
 const TAG_COMPOUND: i8 = 10;
 const TAG_INT_ARRAY: i8 = 11;
 
-pub struct NbtReader<'a, R: 'a> {
-    reader: &'a mut R
+pub struct NbtReader<R> {
+    reader: R
 }
 
 fn byteorder_to_io_result<T>(res: byteorder::Result<T>) -> io::Result<T> {
@@ -168,8 +168,8 @@ fn byteorder_to_io_result<T>(res: byteorder::Result<T>) -> io::Result<T> {
     }
 }
 
-impl<'a, R: Read> NbtReader<'a, R> {
-    pub fn new(reader: &'a mut R) -> NbtReader<'a, R> {
+impl<R: Read> NbtReader<R> {
+    pub fn new(reader: R) -> NbtReader<R> {
         NbtReader {
             reader: reader
         }

--- a/src/minecraft/nbt.rs
+++ b/src/minecraft/nbt.rs
@@ -1,4 +1,3 @@
-use std::array::*;
 use std::collections::HashMap;
 use std::fmt;
 use std::io::{ Read, BufReader};

--- a/src/minecraft/region.rs
+++ b/src/minecraft/region.rs
@@ -3,7 +3,6 @@ use std::fs::{File, Metadata};
 use std::io;
 use std::path::Path;
 use std::os::unix::io::AsRawFd;
-use std::os;
 use gfx;
 use mmap;
 

--- a/src/minecraft/region.rs
+++ b/src/minecraft/region.rs
@@ -2,8 +2,8 @@ use std::cell::RefCell;
 use std::fs::{File, Metadata};
 use std::io;
 use std::path::Path;
-use std::os::unix::io::AsRawFd;
 use gfx;
+use libc;
 use mmap;
 
 use array::*;
@@ -36,13 +36,15 @@ impl Region {
     pub fn open(filename: &Path) -> io::Result<Region> {
         #[cfg(not(windows))]
         fn map_fd(file: &File) -> mmap::MapOption {
+            use std::os::unix::io::AsRawFd;
             mmap::MapOption::MapFd(file.as_raw_fd())
         }
 
         #[cfg(windows)]
         fn map_fd(file: &File) -> mmap::MapOption {
-            use std::os::windows::AsRawHandle;
-            mmap::MapOption::MapFd(file.as_raw_handle())
+            use std::os::windows::io::AsRawHandle;
+            let handle: libc::HANDLE = file.as_raw_handle() as libc::HANDLE;
+            mmap::MapOption::MapFd(handle)
         }
 
         let file = try!(File::open(filename));

--- a/src/minecraft/region.rs
+++ b/src/minecraft/region.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::fs::{File, Metadata};
 use std::io;
 use std::path::Path;
-use std::sys::ext::io::AsRawFd;
+use std::os::unix::io::AsRawFd;
 use std::os;
 use gfx;
 use mmap;
@@ -146,7 +146,7 @@ impl Region {
         Some(ChunkColumn {
             chunks: chunks,
             buffers: Array::from_fn(|_| RefCell::new(None)),
-            biomes: Array::from_fn(|z| -> [BiomeId; SIZE] { 
+            biomes: Array::from_fn(|z| -> [BiomeId; SIZE] {
                 Array::from_fn(|x| {
                     BiomeId {
                         value: biomes[z * SIZE + x]

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -79,7 +79,7 @@ impl<R: gfx::device::Resources, C: gfx::device::draw::CommandBuffer<R>,
     F: gfx::device::Factory<R>, D: gfx::Device<Resources=R, CommandBuffer=C>>
     Renderer<D, F> {
 
-    pub fn new(mut device: D, mut factory: F, frame: gfx::Frame<D::Resources>,
+    pub fn new(device: D, mut factory: F, frame: gfx::Frame<D::Resources>,
                tex: gfx::handle::Texture<D::Resources>) -> Renderer<D, F> {
         let sampler = factory.create_sampler(
                 gfx::tex::SamplerInfo::new(

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -66,21 +66,22 @@ pub struct Buffer<R: gfx::Resources> {
     batch: gfx::batch::RefBatch<ShaderParam<R>>,
 }
 
-pub struct Renderer<D: Device, F: gfx::device::Factory<D::Resources>> {
+pub struct Renderer<D: Device, F: gfx::device::Factory<D::Resources>, O: gfx::Output<D::Resources>> {
     graphics: gfx::Graphics<D, F>,
     params: ShaderParam<D::Resources>,
-    frame: gfx::Frame<D::Resources>,
+    frame: O,
     cd: gfx::ClearData,
     prog: gfx::handle::Program<D::Resources>,
     drawstate: gfx::DrawState
 }
 
 impl<R: gfx::device::Resources, C: gfx::device::draw::CommandBuffer<R>,
-    F: gfx::device::Factory<R>, D: gfx::Device<Resources=R, CommandBuffer=C>>
-    Renderer<D, F> {
+    F: gfx::device::Factory<R>, D: gfx::Device<Resources=R, CommandBuffer=C>,
+    O: gfx::Output<R>>
+    Renderer<D, F, O> {
 
-    pub fn new(device: D, mut factory: F, frame: gfx::Frame<D::Resources>,
-               tex: gfx::handle::Texture<D::Resources>) -> Renderer<D, F> {
+    pub fn new(device: D, mut factory: F, frame: O,
+               tex: gfx::handle::Texture<D::Resources>) -> Renderer<D, F, O> {
         let sampler = factory.create_sampler(
                 gfx::tex::SamplerInfo::new(
                     gfx::tex::FilterMethod::Scale,


### PR DESCRIPTION
Not currently working, but progress has been made:
* `cargo update`
* `flate` -> `flate2` (crates.io)
* `os::MemoryMap` -> `mmap`
* `rustc-serialize` `0.2.8` -> `0.3.x`
* `range(a, b)` -> `a..b`
* `old_io` -> `io`
* Other misc changes.

Most of the grunt work has been done to update hematite for rust nightly/beta, and the ever-changing gfx-rs and piston. Currently, what's left to be done is to disentangle the Renderer type from Device/Factory in `shader.rs`, and `block_state.rs` (or some other solution) to finish removing quack. In fact, if you know what you're doing, it might be easier to start with the `shader.rs` from master and work from there since the one in the PR was committed in the middle of me trying to understand the web of inheritance going on there.

A potential papercut to note: I didn't notice at the time but the mmap crate from crates.io might not work on Windows right now (PR Pending ?).