### PR TITLE
Updated "hematite" on crates.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
 rust:
-    - stable
     - nightly
 notifications:
     irc: "irc.mozilla.org#piston-internals"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "hematite"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "camera_controllers 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 
 name = "hematite"
-version = "0.0.1"
+version = "0.0.2"
 license = "MIT"
 authors = ["bvssvni <bvssvni@gmail.com>"]
-tags = ["minecraft", "piston", "client"]
+keywords = ["minecraft", "piston", "client"]
 description = "A simple Minecraft client"
 repository = "https://github.com/PistonDevelopers/hematite.git"
 homepage = "http://hematite.piston.rs"


### PR DESCRIPTION
- Removed “stable” from .travis.yml (bug in cargo doc)
- Bumped to 0.0.2
- Fixed keywords in Cargo.toml