### PR TITLE
Fix Nbt::from_gzip for the flate2 API.

### DIFF
--- a/src/minecraft/nbt.rs
+++ b/src/minecraft/nbt.rs
@@ -90,8 +90,7 @@ impl Nbt {
     }
 
     pub fn from_gzip(data: &[u8]) -> NbtReaderResult<Nbt> {
-        assert_eq!(&data[..4], &[0x1fu8, 0x8b, 0x08, 0x00]);
-        let reader = GzDecoder::new(&data[10..]).unwrap();
+        let reader = GzDecoder::new(data).unwrap();
         Nbt::from_reader(reader)
     }
 


### PR DESCRIPTION
The old `assert!` and skipping the first 10 bytes were for raw DEFLATE, `GzDecoder` handles all of that itself.