### PR TITLE
Tweaks suggested by clippy

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -34,16 +34,10 @@ impl LightLevel {
 pub const SIZE: usize = 16;
 
 /// A chunk of SIZE x SIZE x SIZE blocks, in YZX order.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Chunk {
     pub blocks: [[[BlockState; SIZE]; SIZE]; SIZE],
     pub light_levels: [[[LightLevel; SIZE]; SIZE]; SIZE]
-}
-
-impl Clone for Chunk {
-    fn clone(&self) -> Chunk {
-        *self
-    }
 }
 
 // TODO: Change to const pointer.

--- a/src/minecraft/biome.rs
+++ b/src/minecraft/biome.rs
@@ -44,7 +44,7 @@ impl Biomes {
 impl Index<BiomeId> for Biomes {
     type Output = Biome;
 
-    fn index<'a>(&'a self, id: BiomeId) -> &'a Biome {
+    fn index(&self, id: BiomeId) -> &Biome {
         self.biomes[id.value as usize].as_ref().unwrap()
     }
 }

--- a/src/minecraft/block_state.rs
+++ b/src/minecraft/block_state.rs
@@ -375,7 +375,7 @@ impl<R: gfx::Resources> BlockStates<R> {
         }
     }
 
-    pub fn get_model<'a>(&'a self, i: BlockState) -> Option<&'a ModelAndBehavior> {
+    pub fn get_model(&self, i: BlockState) -> Option<&ModelAndBehavior> {
         let i = i.value as usize;
         if i >= self.models.len() || self.models[i].is_empty() {
             None
@@ -384,7 +384,7 @@ impl<R: gfx::Resources> BlockStates<R> {
         }
     }
 
-    pub fn texture<'a>(&'a self) -> &'a Texture<R> {
+    pub fn texture(&self) -> &Texture<R> {
         &self.texture
     }
 
@@ -423,7 +423,7 @@ pub fn fill_buffer<R: gfx::Resources>(block_states: &BlockStates<R>,
                         let mut i = 0;
                         let result;
                         loop {
-                            let (cond, idx) = match model.polymorph_oracle[i].clone() {
+                            let (cond, idx) = match model.polymorph_oracle[i] {
                                 PickBlockState(id) => {
                                     result = &block_states.models[id as usize];
                                     break;
@@ -460,7 +460,7 @@ pub fn fill_buffer<R: gfx::Resources>(block_states: &BlockStates<R>,
                     None => continue
                 };
                 let block_xyz = vec3_add([x, y, z].map(|x| x as f32), chunk_xyz);
-                let block_xyz = match model.random_offset.clone() {
+                let block_xyz = match model.random_offset {
                     RandomOffset::None => block_xyz,
                     random_offset => {
                         let (x, z) = (block_xyz[0], block_xyz[2]);
@@ -590,7 +590,7 @@ pub fn fill_buffer<R: gfx::Resources>(block_states: &BlockStates<R>,
                     });
 
                     // Split the clockwise quad into two clockwise triangles.
-                    buffer.extend([0,1,2,2,3,0].iter().map(|&i| v[i].clone()));
+                    buffer.extend([0,1,2,2,3,0].iter().map(|&i| v[i]));
                 }
             }
         }

--- a/src/minecraft/nbt.rs
+++ b/src/minecraft/nbt.rs
@@ -111,7 +111,7 @@ impl Nbt {
         match self { Nbt::List(List::Compound(c)) => Ok(c), x => Err(x) }
     }
 
-    pub fn as_bytearray<'a>(&'a self) -> Option<&'a [u8]> {
+    pub fn as_bytearray(&self) -> Option<&[u8]> {
         match *self { Nbt::ByteArray(ref b) => Some(&b[..]), _ => None }
     }
 
@@ -119,11 +119,11 @@ impl Nbt {
         match self { Nbt::ByteArray(b) => Ok(b), x => Err(x) }
     }
 
-    pub fn as_float_list<'a>(&'a self) -> Option<&'a [f32]> {
+    pub fn as_float_list(&self) -> Option<&[f32]> {
         match *self { Nbt::List(List::Float(ref f)) => Some(&f[..]), _ => None }
     }
 
-    pub fn as_double_list<'a>(&'a self) -> Option<&'a [f64]> {
+    pub fn as_double_list(&self) -> Option<&[f64]> {
         match *self { Nbt::List(List::Double(ref d)) => Some(&d[..]), _ => None }
     }
 }
@@ -226,13 +226,8 @@ impl<R: Read> NbtReader<R> {
 
     fn compound(&mut self) -> NbtReaderResult<Compound> {
         let mut map = HashMap::new();
-        loop {
-            match try!(self.tag()) {
-                Some((v, name)) => {
-                    map.insert(name, v);
-                }
-                None => break
-            }
+        while let Some((v, name)) = try!(self.tag()) {
+            map.insert(name, v);
         }
         Ok(map)
     }

--- a/src/minecraft/region.rs
+++ b/src/minecraft/region.rs
@@ -36,7 +36,7 @@ impl Region {
         Ok(Region{mmap: mmap})
     }
 
-    fn as_slice<'a>(&'a self) -> &'a [u8] {
+    fn as_slice(&self) -> &[u8] {
         unsafe {
             self.mmap.as_slice()
         }

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -81,7 +81,7 @@ impl<R: gfx::Resources, F: gfx::Factory<R>> Renderer<R, F> {
         let texture_view = factory.view_texture_as_shader_resource::<gfx::format::Rgba8>(
             &tex, (0, 0), gfx::format::Swizzle::new()).unwrap();
 
-        let prog = factory.link_program(VERTEX.clone(), FRAGMENT.clone()).unwrap();
+        let prog = factory.link_program(VERTEX, FRAGMENT).unwrap();
 
         let mut rasterizer = gfx::state::Rasterizer::new_fill(gfx::state::CullFace::Back);
         rasterizer.front_face = gfx::state::FrontFace::Clockwise;


### PR DESCRIPTION
This is a selection of the tweaks that [clippy](https://github.com/Manishearth/rust-clippy) suggested. The majority of fixes that clippy suggested weren't ones I was sure were better:
- `x.iter()` => `&x`; `x.iter_mut()` => `&mut x`.
-  `match { Some(x) => {...}, None => {} }` => `if let(x) = Some(y) {...}` which I left in since all of the surrounding code was using match.
- Appending Error to variants of an Error enum.

I'll leave this up for a few days before merging in case anyone wants to indulge in bikeshedding :wink:.